### PR TITLE
Bower and handling of external dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "es6-module-loader",
+  "version": "0.2.1",
+  "description": "An ES6 Module Loader polyfill based on the latest spec.",
+  "homepage": "https://github.com/ModuleLoader/es6-module-loader",
+  "main": "dist/es6-module-loader.js",
+  "keywords": [
+    "es6",
+    "harmony",
+    "polyfill",
+    "modules"
+  ],
+  "ignore": [
+    "demo",
+    "dist/*.min.js",
+    "lib",
+    "test",
+    "grunt.js",
+    "package.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ModuleLoader/es6-module-loader.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT"
+    }
+  ],
+  "dependencies": {
+    "esprima": "~1.0.3"
+  }
+}


### PR DESCRIPTION
I think it's worth discussing how `es6-module-loader` should handle the esprima dependency when installed via a package manager. Since `esprima` is loaded lazily and the loader expects it in a certain place, it should be included in the package. Vendoring external dependencies, however, is nonoptimal when using package managers.

I attached a sample `bower.json` that excludes the bundled esprima version and lists it as dependency. How would you like to handle this?
