### PR TITLE
adding support for script defer, improving the resolution process for `data-esprima-src`

### DIFF
--- a/lib/es6-module-loader.js
+++ b/lib/es6-module-loader.js
@@ -536,13 +536,13 @@
           return callback();
 
         var curScript;
+        var esprimaSrc;
         for (var i = 0; i < scripts.length; i++) {
           curScript = scripts[i];
-          if (scripts[i].getAttribute('data-esprima-src')) {
-            break;
-          }
+          // the first script with `data-esprima-src` wins!
+          esprimaSrc = esprimaSrc || curScript.getAttribute('data-esprima-src');
         }
-        var esprimaSrc = curScript.getAttribute('data-esprima-src') || curScript.src.substr(0, curScript.src.lastIndexOf('/') + 1) + 'esprima-es6.min.js';
+        esprimaSrc = esprimaSrc || curScript.src.substr(0, curScript.src.lastIndexOf('/') + 1) + 'esprima-es6.min.js';
         var self = this;
         System.load(esprimaSrc, function() {
           self.esprima = System.global.esprima;


### PR DESCRIPTION
If injecting `es6-module-loader` dynamically or using `defer` on the script tag, the resolution of esprima `src` is going to be a little bit more complex. Aside from that, moving the `esprimaSrc` computation into `loadEsprima` method makes more sense in preparation for forking the logic if the browser supports es6 modules.
