### PR TITLE
Support IE 8 (surround reserved keywords used as object keys with bracke...

### DIFF
--- a/lib/es6-module-loader.js
+++ b/lib/es6-module-loader.js
@@ -16,7 +16,7 @@
       try {
         Object.defineProperty(obj, prop, opt);
       }
-      catch {
+      catch (e) {
         obj[prop] = opt.value || opt.get.call(obj);
       }
     };
@@ -76,6 +76,14 @@
       Global.prototype = this._builtins;
 
       this._global = new Global();
+
+      defineProperty(this, "global", {
+        configurable: true,
+        enumerable: true,
+        get: function () {
+          return this._global;
+        }
+      });
       defineProperty(this._global, 'window', { value: this._global });
 
       this._strict = !!options.strict;
@@ -98,13 +106,6 @@
       this._sloads = {};
     }
 
-    defineProperty(Loader.prototype, "global", {
-      configurable: true,
-      enumerable: true,
-      get: function () {
-        return this._global;
-      }
-    });
 
     // Loader.prototype.load( address, callback, errback [, referer = null] )
     //


### PR DESCRIPTION
Support IE 8 (surround reserved keywords used as object keys with bracket syntax, provide try-catch workarounds for Object.defineProperty). Sets Loader "global" property and mixed-in Module properties directly in order to polyfill for IE

Very sorry about having deleted the old comments by deleting the old repository. My old commit was on master, so not sure if I could reset the tree in a way that Github would accept while avoiding including unnecessary commits in the pull request.
