### PR TITLE
Traceur: Update to use explicit parseModule

### DIFF
--- a/lib/es6-module-loader.js
+++ b/lib/es6-module-loader.js
@@ -519,14 +519,14 @@
       },
       fetch: fetch,
       translate: function (source, options) {
-				if (!global.traceur || options.address == esprimaSrc)
-					return source;
-					
-				var traceur = global.traceur;
+        if (!global.traceur || options.address == esprimaSrc)
+          return source;
+
+        var traceur = global.traceur;
 
         var project = new traceur.semantics.symbols.Project(options.address);
         traceur.options.sourceMaps = true;
-				traceur.options.modules = 'parse';
+        traceur.options.modules = 'parse';
 
         var reporter = new traceur.util.ErrorReporter();
         reporter.reportMessageInternal = function(location, kind, format, args) {
@@ -534,13 +534,16 @@
         }
 
         var sourceFile = new traceur.syntax.SourceFile(options.address, source);
-        project.addFile(sourceFile);
-        var res = traceur.codegeneration.Compiler.compile(reporter, project, false);
+        var parser = new traceur.syntax.Parser(reporter, sourceFile);
+        var tree = parser.parseModule();
+
+        var transformer = new traceur.codegeneration.ProgramTransformer(reporter, project);
+        tree = transformer.transform(tree);
 
         var sourceMapGenerator = new traceur.outputgeneration.SourceMapGenerator({ file: options.address });
         var opt = { sourceMapGenerator: sourceMapGenerator };
 
-        source = traceur.outputgeneration.ProjectWriter.write(res, opt);
+        source = traceur.outputgeneration.TreeWriter.write(tree, opt);
         if (isBrowser)
           source += '\n//# sourceMappingURL=data:application/json;base64,' + btoa(opt.sourceMap) + '\n';
 


### PR DESCRIPTION
Update test/traceur.js to 496d26c66afc6c31f27ab83dc9efddbd9726da5c and update lib/es6-module-loader.js to work with that.

The reason for this change is that Traceur Compiler does not know how to distinguish between Script or Module top level syntax
