### PR TITLE
Allowing newer versions of traceur to be used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "lib/es6-module-loader.js"
   ],
   "dependencies": {
-    "traceur": "0.0.8"
+    "traceur": "~0.0.8"
   }
 }


### PR DESCRIPTION
As it says on the description it would be nice to `npm dedupe` and flatten the package hierarchy when using newer versions of traceur.
