### PR TITLE
Use strings around reserved word catch

### DIFF
--- a/lib/es6-module-loader.js
+++ b/lib/es6-module-loader.js
@@ -112,7 +112,7 @@
 
         // Create and return the promise (reusing the callback variable)
         callback.call(callback = { then: function (resolved, rejected) { return handler(resolved, rejected); }, 
-                                    catch: function (rejected)           { return handler(0,        rejected); } },
+                                    'catch': function (rejected)           { return handler(0,        rejected); } },
                       function(value)  { handler(is, 1,  value); },
                       function(reason) { handler(is, 0, reason); });
         return callback;


### PR DESCRIPTION
Currently breaking in some versions of IE.
