### PR TITLE
Use module name when __sourceUrl undefined

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -720,8 +720,8 @@ function logloads(loads) {
         ? '\n//# sourceURL=' + __sourceURL : ''));
     }
     catch(e) {
-      if (e.name == 'SyntaxError')
-        e.message = 'Evaluating ' + __sourceURL + '\n\t' + e.message;
+      if (e.name == 'SyntaxError') 
+        e.message = 'Evaluating ' + (__sourceURL || __moduleName) + '\n\t' + e.message;
       throw e;
     }
   }


### PR DESCRIPTION
When an error occurs during __eval, fall back to module name value when
sourceUrl is undefined.
