### PR TITLE
traceur location

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -7,7 +7,7 @@
 
 
   <!-- set this to the path to traceur.js -->
-  <script src="../../traceur-compiler/bin/traceur.js"></script>
+  <script src="../node_modules/traceur/bin/traceur.js"></script>
 
   <script>
     // test promise polyfill


### PR DESCRIPTION
the tests depend on a copy of the traceur repo being cloned in the folder next to where this is cloned to.  This changes the link to point to the copy you already have in node_modules
