### PR TITLE
Set Loader.prototype.constructor

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -880,6 +880,7 @@ function logloads(loads) {
     // importPromises adds ability to import a module twice without error - https://bugs.ecmascript.org/show_bug.cgi?id=2601
     var importPromises = {};
     Loader.prototype = {
+      constructor: Loader,
       define: function(name, source, options) {
         if (importPromises[name])
           throw new TypeError('Module is already loading.');


### PR DESCRIPTION
This allows subclass constructors to call the `Loader` constructor via `super`.

Fixes #153.
