### PR TITLE
Propogate module errors with a trace

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -873,7 +873,7 @@ function logloads(loads) {
     function evaluateLoadedModule(loader, load) {
       console.assert(load.status == 'linked', 'is linked ' + load.name);
 
-      ensureEvaluated(load.module, [], loader);
+      doEnsureEvaluated(load.module, [], loader);
       return load.module.module;
     }
 
@@ -885,20 +885,22 @@ function logloads(loads) {
      * module.dependencies  list of module objects for dependencies
      *
      */
-
-    // execution errors don't propogate in the pipeline
-    // see https://bugs.ecmascript.org/show_bug.cgi?id=2993
     function doExecute(module) {
       try {
         module.execute.call(__global);
       }
       catch(e) {
-        setTimeout(function() {
-          throw e;
-        });
+        return e;
       }
     }
 
+    // propogate execution errors
+    // see https://bugs.ecmascript.org/show_bug.cgi?id=2993
+    function doEnsureEvaluated(module, seen, loader) {
+      var err = ensureEvaluated(module, seen, loader);
+      if (err)
+        throw err;
+    }
     // 15.2.6.2 EnsureEvaluated adjusted
     function ensureEvaluated(module, seen, loader) {
       if (module.evaluated || !module.dependencies)
@@ -907,20 +909,31 @@ function logloads(loads) {
       seen.push(module);
 
       var deps = module.dependencies;
+      var err;
 
       for (var i = 0; i < deps.length; i++) {
         var dep = deps[i];
-        if (indexOf.call(seen, dep) == -1)
-          ensureEvaluated(dep, seen, loader);
+        if (indexOf.call(seen, dep) == -1) {
+          err = ensureEvaluated(dep, seen, loader);
+          // stop on error, see https://bugs.ecmascript.org/show_bug.cgi?id=2996
+          if (err)
+            return err + '\n  in module ' + dep.name;
+        }
       }
+
+      if (module.failed)
+        return new Error('Module failed execution.');
 
       if (module.evaluated)
         return;
 
       module.evaluated = true;
-      doExecute(module);
+      err = doExecute(module);
+      if (err)
+        module.failed = true;
       module.module = _newModule(module.exports);
-      delete module.execute;
+      module.execute = undefined;
+      return err;
     }
 
     // 26.3 Loader
@@ -998,7 +1011,7 @@ function logloads(loads) {
       get: function(key) {
         if (!this._loader.modules[key])
           return;
-        ensureEvaluated(this._loader.modules[key], [], this);
+        doEnsureEvaluated(this._loader.modules[key], [], this);
         return this._loader.modules[key].module;
       },
       // 26.3.3.7
@@ -1016,7 +1029,7 @@ function logloads(loads) {
           var loader = loaderObj._loader;
 
           if (loader.modules[name]) {
-            ensureEvaluated(loader.modules[name], [], loader._loader);
+            doEnsureEvaluated(loader.modules[name], [], loader._loader);
             return loader.modules[name].module;
           }
 
@@ -1032,7 +1045,7 @@ function logloads(loads) {
       // 26.3.3.10
       load: function(name, options) {
         if (this._loader.modules[name]) {
-          ensureEvaluated(this._loader.modules[name], [], this._loader);
+          doEnsureEvaluated(this._loader.modules[name], [], this._loader);
           return Promise.resolve(this._loader.modules[name].module);
         }
         return importPromises[name] || createImportPromise(name, loadModule(this._loader, name, {}));

--- a/test/test.js
+++ b/test/test.js
@@ -297,9 +297,9 @@ function runTests() {
 
   test('Error check 1', function(assert) {
     System['import']('loads/main').then(function(m) {
-      assert(!!m, true);
+      assert(false, true);
     }, function(e) {
-      assert(false, 'caught');
+      assert(e, 'dep error\n  in module loads/deperror');
     });
     // System['import']('loads/deperror');
   });


### PR DESCRIPTION
In line with recent es-discuss post and spec bugs https://bugs.ecmascript.org/show_bug.cgi?id=2996, https://bugs.ecmascript.org/show_bug.cgi?id=2993.

Modules marked as failed in the module table when there is an execution error, as well as any module importing from them.
