### PR TITLE
Fix baseURL documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ All modules are loaded relative to the `baseURL`, which by default is set to the
 We can alter this with:
 
 ```javascript
-  System.baseURL = '/js/lib';
+  System.baseURL = '/js/lib/';
   System.import('module'); // now loads "/js/lib/module.js"
 ```
 


### PR DESCRIPTION
As far as I can see the `baseURL` is trimmed until the [last index of `/`](https://github.com/ModuleLoader/es6-module-loader/blob/master/lib/system.js#L319). So in order to achieve the load from `/js/lib/module.js` there is a trailing slash needed.

I have only tested it in the browser.
