### PR TITLE
Make exact matches win for path lookup

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -235,8 +235,10 @@
 
           // exact path match
           if (pathParts.length == 1) {
-            if (name == p && p.length > pathMatch.length)
+            if (name == p && p.length > pathMatch.length) {
               pathMatch = p;
+              break;
+            }
           }
 
           // wildcard path match

--- a/test/test.js
+++ b/test/test.js
@@ -388,7 +388,9 @@ function runTests() {
   });
 
   test('Custom path most specific', function(assert) {
+    delete System.paths['bar/*'];
     System.paths['bar/bar'] = 'loader/specific-path.js';
+    System.paths['bar/*'] = 'loader/custom-folder/*.js';
     System['import']('bar/bar').then(function(m) {
       assert(m.path, true);
     });


### PR DESCRIPTION
This fixes a bug where when a wildcard path is specified _after_ an exact path the wildcard would win.  The reason is that for/in loops go in the order that the keys were defined. Deleting the key and re-adding it shows the error. The fix is simply to break out the loop once we find an exact match. Fixes #189
