### PR TITLE
Normalize module identifier lookups with get call

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -912,6 +912,7 @@ function logloads(loads) {
       // 26.3.3.4 entries not implemented
       // 26.3.3.5
       get: function(key) {
+        key = this.normalize(key);
         if (!this._loader.modules[key])
           return;
         doEnsureEvaluated(this._loader.modules[key], [], this);


### PR DESCRIPTION
It seems incredibly odd to me that you import using a module name and
then resolve the `get` call with the fully normalized path.  This makes
very little sense to me:

```
// Assume System#normalize has been monkey patched.

System.import('./some/path/to/module').then(function() {
  System.get('/normalized/path/to/module');
});
```

This patch ensures that `get` lookups match the import path.
