### PR TITLE
add failing test for generator export

### DIFF
--- a/test/syntax/es6-generator.js
+++ b/test/syntax/es6-generator.js
@@ -1,0 +1,3 @@
+export function* generator() {
+  yield 1;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -200,6 +200,12 @@ function runTests() {
     }, err);
   });
 
+  test('Import ES6 Generator', function(assert, err) {
+    System['import']('syntax/es6-generator').then(function(m) {
+      assert(!!m.generator, true);
+    }, err);
+  });
+
   test('Direct import without bindings', function(assert, err) {
     System['import']('syntax/direct').then(function(m) {
       assert(!!m, true);


### PR DESCRIPTION
At first glance it seems to be an easy-to-fix bug in traceur-compiler, but the test doesn't fail as a traceur-compiler test. :confused:
