### PR TITLE
add support for environments with both window and global

### DIFF
--- a/src/polyfill-wrapper-end.js
+++ b/src/polyfill-wrapper-end.js
@@ -26,4 +26,4 @@ function __eval(__source, __global, load) {
   System.register = __curRegister;
 }
 
-})(typeof global !== 'undefined' ? global : this);
+})(typeof window == 'undefined' ? global : this);


### PR DESCRIPTION
Browsers will always have `window` and possibly `global` with node-webkit (or similar).
Node will never have `window` but always have `global`.
