### PR TITLE
Fix IE8/IE9 bug that may cause hanging cross-domain requests.

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -77,6 +77,10 @@
         xhr.onload = load;
         xhr.onerror = error;
         xhr.ontimeout = error;
+        // IE8/IE9 bug may hang requests unless all properties are defined. 
+        // See: http://stackoverflow.com/a/9928073/3949247
+        xhr.onprogress = function() {};
+        xhr.timeout = 0;
       }
       function load() {
         fulfill(xhr.responseText);


### PR DESCRIPTION
When loading JS modules from another domain with StealJS, IE9 would not finish loading until I applied this patch. 

See following descriptions of bug and workaround:

http://stackoverflow.com/questions/7037627/long-poll-and-ies-xdomainrequest-object/9928073#9928073

http://social.msdn.microsoft.com/Forums/ie/en-US/30ef3add-767c-4436-b8a9-f1ca19b4812e/ie9-rtm-xdomainrequest-issued-requests-may-abort-if-all-event-handlers-not-specified?forum=iewebdevelopment

(This was originally proposed in https://github.com/bitovi/steal/pull/252)
