### PR TITLE
Fix TypeError when iterating over load.dependencies.

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -410,6 +410,9 @@ function logloads(loads) {
     var loader = linkSet.loader;
 
     for (var i = 0, l = load.dependencies.length; i < l; i++) {
+      if (!load.dependencies[i])
+        continue;
+      
       var name = load.dependencies[i].value;
 
       if (loader.modules[name])
@@ -566,6 +569,8 @@ function logloads(loads) {
 
       // dependencies not found are already linked
       for (var j = 0; j < load.dependencies.length; j++) {
+        if (!load.dependencies[j])
+          continue;
         if (loadDep.name == load.dependencies[j].value) {
           // by definition all loads in linkset are loaded, not linked
           console.assert(loadDep.status == 'loaded', 'Load in linkSet not loaded!');
@@ -695,6 +700,8 @@ function logloads(loads) {
     // now link all the module dependencies
     // amending the depMap as we go
     for (var i = 0, l = load.dependencies.length; i < l; i++) {
+      if (!load.dependencies[i])
+        continue;
       var depName = load.dependencies[i].value;
       var depModule = loader.modules[depName];
 


### PR DESCRIPTION
I'm not 100% sure about this change, but I have encountered a TypeError: undefined error on the loop over `load.dependencies` in section `// 15.2.5.2.2`, that this fixes. Unfortunately, I don't know enough about the surrounding logic to know whether the whole dependencies array *should* be getting populated.

It appears as though load.dependencies should be considered a sparse array, based on this code block in `src/loader.js` that builds `load.dependencies`:

      // 15.2.4.6 ProcessLoadDependencies
      load.dependencies = [];

      ...

      // adjusted from spec to maintain dependency order
      // this is due to the System.register internal implementation needs
      load.dependencies[index] = {
        key: request,
        value: depLoad.name
      };

More details about the error:

* I'm progressively-loading an app with StealJS.
* I'm seeing this on Safari iOS 7.1 for iPad.
* It's an intermittent error, it occurs perhaps 10%-20% of the time. The rest of the time, the page loads correctly without error.
* The fix here does seem to fix my error - I've seen with logging that it prevents the error, and that the page continues to load properly.
* The load.dependencies entry that is missing is always related to a mustache template. There's some extension that mustache templates are loaded through.
* The `load.dependencies` at time of error looks like this:

```
load.dependencies[0] = { key: 'jquery/jquery', value: 'jquery' }
// load.dependencies[1] is not defined, which is why load.dependencies[i].value fails
load.dependencies[2] = { key: 'app/core/core', value: 'app/core/core' }
...
```
* The `load.depsList` at time of error looks like this:

```
load.depsList[0] = 'jquery/jquery'
load.depsList[1] = 'some_template.mustache!' // this entry is missing in load.dependencies
load.depsList[2] = 'app/core/core'
...
```



