### PR TITLE
Reflect.isModule implementation

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1062,6 +1062,9 @@ function logloads(loads) {
   __global.Reflect.Loader = __global.Reflect.Loader || Loader;
   __global.Reflect.global = __global.Reflect.global || __global;
   __global.LoaderPolyfill = Loader;
+  __global.Reflect.isModule = function(m) {
+    return m instanceof Module;
+  }
 
 })();
 

--- a/test/test.js
+++ b/test/test.js
@@ -206,6 +206,12 @@ function runTests() {
     }, err);
   });
 
+  test('Reflect.isModule', function(assert, err) {
+    System['import']('syntax/es6').then(function(m) {
+      assert(Reflect.isModule(m), true);
+    }, err);
+  });
+
   test('Direct import without bindings', function(assert, err) {
     System['import']('syntax/direct').then(function(m) {
       assert(!!m, true);


### PR DESCRIPTION
This provides an implementation for `Reflect.isModule`.

We use `instanceof` with a `Module` class simply for implementation simplicity, even though Module objects aren't classes, to avoid adding hidden properties.
