### PR TITLE
Better error message stacks

### DIFF
--- a/test/loads/load-non-existent.js
+++ b/test/loads/load-non-existent.js
@@ -1,0 +1,1 @@
+import 'non-existent';

--- a/test/test.html
+++ b/test/test.html
@@ -15,7 +15,7 @@
 
   <script src="../node_modules/when/es6-shim/Promise.js"></script>
 
-  <script src="../dist/es6-module-loader.js"></script>
+  <script src="../dist/es6-module-loader.src.js"></script>
   <script>
     // test traceurOptions and anonymous errors
     // System.traceurOptions = { classes: false };

--- a/test/test.js
+++ b/test/test.js
@@ -307,13 +307,13 @@ function runTests() {
     System['import']('loads/main').then(function(m) {
       assert(false, true);
     }, function(e) {
-      assert(e, 'dep error\n  in module loads/deperror');
+      assert(e, 'Error evaluating loads/deperror\ndep error');
     });
     // System['import']('loads/deperror');
   });
 
   test('Unhandled rejection test', function(assert) {
-    System['import']('non-existent');
+    System['import']('loads/load-non-existent')
     assert();
   });
 


### PR DESCRIPTION
This will enable the following:
- When an error occurs in a dynamic module load, the error will be reported, along with the name of the module and the names of the modules loading that module.
- When there is a fetch error (eg 404) / locate error etc, the error will be reported with the name of the module and the names of all the module dependent on that module. This makes it possible to see which module is the root cause of the 404 request.

This resolves #233 and #217.
