### PR TITLE
Add //# sourceURL along with source map.

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1103,8 +1103,10 @@ function logloads(loads) {
 
       var sourceMap = compiler.getSourceMap();
 
-      if (__global.btoa && sourceMap)
+      if (__global.btoa && sourceMap) {
+        source += '\n//# sourceURL=' + load.address + '!eval';
         source += '\n//# sourceMappingURL=data:application/json;base64,' + btoa(unescape(encodeURIComponent(sourceMap))) + '\n';
+      }
 
       source = 'var __moduleAddress = "' + load.address + '";' + source;
 

--- a/test/manual/source-maps/test.html
+++ b/test/manual/source-maps/test.html
@@ -1,0 +1,13 @@
+<!doctype html>
+  <html>
+
+  <body>
+    <h1>Source Map Stack Trace Test</h1>
+    <script src="../../../node_modules/traceur/bin/traceur.js"></script>
+    <script src="../../../dist/es6-module-loader.src.js"></script>
+    <script>
+      System.import('test').then(function(module) {
+        console.log(module.make().stack)
+      })
+    </script>
+  </body>

--- a/test/manual/source-maps/test.js
+++ b/test/manual/source-maps/test.js
@@ -1,0 +1,4 @@
+export function make() {
+  return new Error('Hello')
+}
+


### PR DESCRIPTION
For some odd reason, Google Chrome requires sourceURL to be able to
display source maps in stack traces correctly.
