### PR TITLE
Bump grunt-contrib-uglify to ~0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt": "~0.4.1",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-contrib-uglify": "~0.6.0",
     "grunt-esnext": "0.0.3",
     "grunt-string-replace": "^0.2.7"
   },


### PR DESCRIPTION
Otherwise, Grunt will not work.

```
Running "uglify:dist" (uglify) task
Warning: Unable to write "true" file (Error code: undefined). Use --force to continue.
```

Apparently, that's because the Gruntfile.js is using the [newer version of configuration](https://github.com/gruntjs/grunt-contrib-uglify#migrating-from-2x-to-3x) than that specified in `package.json`.

Upgrading grunt-contrib-uglify solves the issue.

```
Running "uglify:dist" (uglify) task
>> 1 sourcemap created.
>> 1 file created.

Running "uglify:polyfillOnly" (uglify) task
>> 1 sourcemap created.
>> 1 file created.
```
