### PR TITLE
Remove unused variable

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1084,8 +1084,6 @@ function logloads(loads) {
 
       console.assert(load.source, 'Non-empty source');
 
-      var depsList;
-
       load.isDeclarative = true;
 
       var options = this.traceurOptions || {};


### PR DESCRIPTION
Not seeing this used anywhere - unless there's some crazy hoisting I'm missing
