### PR TITLE
traceur version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "grunt-contrib-uglify": "0.6.0",
-    "traceur": "0.0.74",
+    "traceur": "0.0.79",
     "when": "^3.4.6"
   }
 }


### PR DESCRIPTION
This version supports node-webkit.

Please do a version bump of this module so that other modules can follow.
