### PR TITLE
clean up npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "test": "cd test && node test"
   },
   "dependencies": {
-    "grunt-contrib-uglify": "0.6.0",
     "traceur": "0.0.79",
     "when": "^3.6.4"
   }


### PR DESCRIPTION
grunt-contrib-uglify was present in both dependencies and devDependencies
which probably wasn't intentional