### PR TITLE
chore(travis): better saucelabs name

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -113,7 +113,7 @@ module.exports = function (config) {
     var buildData = options.travis ?
     {
       location: 'TRAVIS',
-      name: process.env.TRAVIS_BUILD_NUMBER,
+      name: process.env.TRAVIS_JOB_NUMBER,
       id: process.env.TRAVIS_BUILD_ID
     }
       :


### PR DESCRIPTION
Replace the TRAVIS_BUILD_NUMBER by the TRAVIS_JOB_NUMBER
So saucelabs can make a difference between the jobs in the same build.
It will log "TRAVIS # 6.1" or "TRAVIS # 6.2" instead of just "TRAVIS # 6"