### PR TITLE
Use 6to5 core, rename parser to transpiler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
       dist: {
         src: [
           'src/loader.js',
-          'src/parser.js',
+          'src/transpiler.js',
           'src/system.js'
         ],
         dest: 'dist/<%= pkg.name %>.js'

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ If using ES6 syntax (optional), include `traceur.js` or `6to5.js` in the page fi
   <script src="es6-module-loader.js"></script>
 ```
 
-To use 6to5, set the parser to `6to5` with the loader configuration:
+To use 6to5, set the transpiler to `6to5` with the loader configuration:
 
 ```html
 <script>
-  System.parser = '6to5';
+  System.transpiler = '6to5';
 </script>
 ```
 
@@ -96,7 +96,7 @@ index.js:
   var System = require('es6-module-loader').System;
   /*  
    *  Include:
-   *    System.parser = '6to5'; 
+   *    System.transpiler = '6to5'; 
    *  to use 6to5 instead of Traceur
    */
 
@@ -125,10 +125,10 @@ _Also, please don't edit files in the "dist" subdirectory as they are generated 
 
 - `npm run test:node` will use node to  to run the tests
 - `npm run test:browser` will run `npm run test:browser-6to5` and `npm run test:browser-traceur`
-- `npm run test:browser-[parser]` use karma to run the tests with traceur or 6to5.
+- `npm run test:browser-[transpiler]` use karma to run the tests with traceur or 6to5.
 - `npm run test:browser:perf` will use karma to run benchmarks
 
-`npm run test:browser-[parser]` supports options after a double dash (`--`) :
+`npm run test:browser-[transpiler]` supports options after a double dash (`--`) :
 
 - You can use the `--polyfill` option to test the code with polyfill.
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,7 +37,7 @@ module.exports = function(config) {
     'test/_helper.js',
     [options['6to5'] ? 'node_modules/regenerator/runtime.js' : ''],
 
-    [!options.ie8 ? (!options['6to5'] ? 'node_modules/traceur/bin/traceur.js' : 'node_modules/6to5/browser.js') : ''],
+    [!options.ie8 ? (!options['6to5'] ? 'node_modules/traceur/bin/traceur.js' : 'node_modules/6to5-core/browser.js') : ''],
 
     'dist/es6-module-loader' + (options.polyfill ? '' : '-sans-promises') + '.src.js',
 

--- a/lib/index-6to5.js
+++ b/lib/index-6to5.js
@@ -1,6 +1,6 @@
 var System = require('../dist/es6-module-loader.src');
 
-System.parser = '6to5';
+System.transpiler = '6to5';
 
 module.exports = {
   Loader: global.LoaderPolyfill,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:browser:perf": "karma start karma-benchmark.conf.js --single-run"
   },
   "dependencies": {
-    "6to5": "^3.0.0",
+    "6to5-core": "~3.3.1",
     "grunt-contrib-uglify": "0.6.0",
     "traceur": "0.0.82",
     "when": "^3.6.4"

--- a/src/loader.js
+++ b/src/loader.js
@@ -251,8 +251,7 @@ function logloads(loads) {
 
         // instead of load.kind, use load.isDeclarative
         load.isDeclarative = true;
-        // parse sets load.declare, load.depsList
-        loader.loaderObj.parse(load);
+        __eval(loader.loaderObj.transpile(load), __global, load);
       }
       else if (typeof instantiateResult == 'object') {
         load.depsList = instantiateResult.deps || [];
@@ -1046,9 +1045,6 @@ function logloads(loads) {
     // 26.3.3.18.4
     translate: function(load) {
       return load.source;
-    },
-    parse: function(load) {
-      throw new TypeError('Loader.parse is not implemented');
     },
     // 26.3.3.18.5
     instantiate: function(load) {

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -1,45 +1,40 @@
 /*
- * Traceur and 6to5 Parsing Code for Loader
+ * Traceur and 6to5 transpile hook for Loader
  */
 (function(Loader) {
-  // parse function is used to parse a load record
   // Returns an array of ModuleSpecifiers
-  var parser, parserModule, parserName, parserOptionsName;
+  var transpiler, transpilerModule;
+  var isNode = typeof window == 'undefined' && typeof WorkerGlobalScope == 'undefined';
 
   // use Traceur by default
-  Loader.prototype.parser = 'traceur';
+  Loader.prototype.transpiler = 'traceur';
 
-  Loader.prototype.parse = function(load) {
-    if (!parser) {
-      parserName = this.parser == '6to5' ? 'to5' : this.parser;
-
-      // try to pick up parser from global or require
-      if (typeof window == 'undefined' && typeof WorkerGlobalScope == 'undefined')
-        parserModule = require(this.parser);
-      else
-        parserModule = __global[parserName];
+  Loader.prototype.transpile = function(load) {
+    if (!transpiler) {
+      if (this.transpiler == '6to5') {
+        transpiler = to5Transpile;
+        transpilerModule = isNode ? require('6to5-core') : __global.to5;
+      }
+      else {
+        transpiler = traceurTranspile;
+        transpilerModule = isNode ? require('traceur') : __global.traceur;
+      }
       
-      if (!parserModule)
-        throw new TypeError('Include Traceur or 6to5 for module syntax support');
-
-      parser = this.parser == '6to5' ? to5Parse : traceurParse;
+      if (!transpilerModule)
+        throw new TypeError('Include Traceur or 6to5 for module syntax support.');
     }
 
-    var source = parser.call(this, load);
-
-    source = 'var __moduleAddress = "' + load.address + '";' + source;
-
-    __eval(source, __global, load);
+    return 'var __moduleAddress = "' + load.address + '";' + transpiler.call(this, load);
   }
 
-  function traceurParse(load) {
+  function traceurTranspile(load) {
     var options = this.traceurOptions || {};
     options.modules = 'instantiate';
     options.script = false;
     options.sourceMaps = 'inline';
     options.filename = load.address;
 
-    var compiler = new parserModule.Compiler(options);
+    var compiler = new transpilerModule.Compiler(options);
     var source = doTraceurCompile(load.source, compiler, options.filename);
 
     // add "!eval" to end of Traceur sourceURL
@@ -58,7 +53,7 @@
     }
   }
 
-  function to5Parse(load) {
+  function to5Transpile(load) {
     var options = this.to5Options || {};
     options.modules = 'system';
     options.sourceMap = 'inline';
@@ -66,7 +61,7 @@
     options.code = true;
     options.ast = false;
 
-    var source = parserModule.transform(load.source, options).code;
+    var source = transpilerModule.transform(load.source, options).code;
 
     // add "!eval" to end of 6to5 sourceURL
     // I believe this does something?

--- a/test/system.spec.js
+++ b/test/system.spec.js
@@ -1,7 +1,7 @@
 //
 
 if (typeof to5 != 'undefined')
-  System.parser = '6to5';
+  System.transpiler = '6to5';
 
 var ie = typeof window != 'undefined' && window.navigator.userAgent.match(/Trident/);
 
@@ -99,7 +99,7 @@ describe('System', function () {
 
     describe('with circular dependencies', function () {
 
-      (System.parser == 'traceur' ? it : it.skip)('should resolve circular dependencies', function (done) {
+      (System.transpiler == 'traceur' ? it : it.skip)('should resolve circular dependencies', function (done) {
         System.import('test/syntax/circular1')
           .then(function (m1) {
             return System.import('test/syntax/circular2').then(function (m2) {
@@ -288,7 +288,7 @@ describe('System', function () {
           .then(done, done);
       });
 
-      (System.parser != 'traceur' ? it.skip : it)('should support re-exporting overwriting', function (done) {
+      (System.transpiler != 'traceur' ? it.skip : it)('should support re-exporting overwriting', function (done) {
         System.import('test/syntax/export-star2')
           .then(function (m) {
             expect(m.bar, 'should re-export "./export-star" bar variable')
@@ -380,7 +380,7 @@ describe('System', function () {
     typeof window != 'undefined' && window.Worker,
     'with Web Worker', function () {
       (ie ? it.skip : it)('should loading inside of a Web Worker', function (done) {
-        var worker = new Worker(System.baseURL + 'test/worker/worker-' + System.parser + '.js');
+        var worker = new Worker(System.baseURL + 'test/worker/worker-' + System.transpiler + '.js');
 
         worker.onmessage = function (e) {
           expect(e.data).to.be.equal('p');

--- a/test/test-6to5.html
+++ b/test/test-6to5.html
@@ -6,7 +6,7 @@
   <script src="test.js"></script>
 
   <!-- set this to the path to 6to5.js -->
-  <script src="../node_modules/6to5/browser.js"></script>
+  <script src="../node_modules/6to5-core/browser.js"></script>
   <script src="../node_modules/regenerator/runtime.js"></script>
 
   <script>
@@ -18,9 +18,7 @@
 
   <script src="../dist/es6-module-loader.src.js"></script>
   <script>
-    System.parser = '6to5';
-    // test parseOptions and anonymous errors
-    // System.parseOptions = { classes: false };
+    System.transpiler = '6to5';
   </script>
 
   <script>

--- a/test/test-traceur.html
+++ b/test/test-traceur.html
@@ -17,8 +17,7 @@
 
   <script src="../dist/es6-module-loader.src.js"></script>
   <script>
-    // test parseOptions and anonymous errors
-    // System.parseOptions = { classes: false };
+    // System.traceurOptions = { classes: false };
   </script>
 
   <script>

--- a/test/worker/worker-6to5.js
+++ b/test/worker/worker-6to5.js
@@ -1,9 +1,9 @@
-importScripts("../../node_modules/6to5/browser.js",
+importScripts("../../node_modules/6to5-core/browser.js",
              "../../node_modules/when/es6-shim/Promise.js",
              "../../dist/es6-module-loader.src.js"
              );
 
-System.parser = '6to5';
+System.transpiler = '6to5';
 
 System['import']('es6').then(function(m) {
   postMessage(m.p);


### PR DESCRIPTION
This is currently failing due to https://github.com/6to5/6to5/issues/654.