### PR TITLE
[1.0] Adjust the demo to the latest spec

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@
   <script src="../node_modules/traceur/bin/traceur.js"></script>
   <script src="../dist/es6-module-loader.js"></script>
   <script type="module">
-    import { hello } from 'test1';
+    import { hello } from './test1.js';
     console.log(hello); // -> world
 
     // es6 syntax
@@ -59,7 +59,7 @@
   <script>
     function buttonClick() {
       // dynamic loading API
-      System.import('test2').then(function(module) {
+      System.import('./test2.js').then(function(module) {
         new module.Foo();
       });
     }


### PR DESCRIPTION
aka add `.js`. My understanding from the [module id -> address change](https://github.com/google/traceur-compiler/issues/1221) is that we should really be using relative paths here too; is that correct? (though both work)