### PR TITLE
move sourceURL part to loader

### DIFF
--- a/src/polyfill-wrapper-end.js
+++ b/src/polyfill-wrapper-end.js
@@ -3,7 +3,11 @@
 // file to avoid adding those references to the evaluation scope.
 function __eval(__source, __global, __load) {
   try {
-    eval('(function() { var __moduleName = "' + (__load.name || '').replace('"', '\"') + '"; ' + __source + ' \n }).call(__global);');
+    // pass sourceURL tag so it will show up correctly in stacktraces
+    eval(
+      '(function() { var __moduleName = "' + (__load.name || '').replace('"', '\"') + '"; ' + __source + ' \n }).call(__global);' +
+      '\n//# sourceURL=' + __load.address + '\n'
+    );
   }
   catch(e) {
     if (e.name == 'SyntaxError' || e.name == 'TypeError')

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -61,10 +61,6 @@
     var compiler = new traceur.Compiler(options);
     var source = doTraceurCompile(load.source, compiler, options.filename);
 
-    // add "!eval" to end of Traceur sourceURL
-    // I believe this does something?
-    source += '!eval';
-
     return source;
   }
   function doTraceurCompile(source, compiler, filename) {
@@ -89,10 +85,7 @@
       options.blacklist = ['react'];
 
     var source = babel.transform(load.source, options).code;
-
-    // add "!eval" to end of Babel sourceURL
-    // I believe this does something?
-    return source + '\n//# sourceURL=' + load.address + '!eval';
+    return source;
   }
 
 


### PR DESCRIPTION
so that it also applies to already transpiled modules

I'm using es6-module-loader to load modules that are already transpiled - but still need the correct #sourceURL mapping for the eval.