### PR TITLE
Added ability to name anonymous modules

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -290,6 +290,7 @@
 
     function ready() {
       var scripts = document.getElementsByTagName('script');
+      var catchFn = function(err) { setTimeout(function() { throw err; }); };
       for (var i = 0; i < scripts.length; i++) {
         var script = scripts[i];
         if (script.type == 'module') {
@@ -297,7 +298,11 @@
           // It is important to reference the global System, rather than the one
           // in our closure. We want to ensure that downstream users/libraries
           // can override System w/ custom behavior.
-          __global.System.module(source)['catch'](function(err) { setTimeout(function() { throw err; }); });
+          if (script.hasAttribute('name')) {
+            __global.System.define(script.getAttribute('name'), source)['catch'](catchFn);
+          } else {
+            __global.System.module(source)['catch'](catchFn);
+          }
         }
       }
     }


### PR DESCRIPTION
When using `<script type="module">` it would be nice to give it a name using something like `<script type="module" name="init-page">` so that it shows up as something other than `<Anonymous Module 1>` in dev tools sources panel.  Plus it would make dynamic scripts specific to the page easily importable and reusable.