### PR TITLE
Track whether transpiler has ran with a flag on the Loader

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -7,8 +7,6 @@
   function getTranspilerModule(loader, globalName) {
     return loader.newModule({ 'default': g[globalName], __useDefault: true });
   }
-  // NB this does not support sub-classing well
-  var firstRun = true;
 
   // use Traceur by default
   Loader.prototype.transpiler = 'traceur';
@@ -17,12 +15,12 @@
     var self = this;
 
     // pick up Transpiler modules from existing globals on first run if set
-    if (firstRun) {
+    if (!self.transpilerHasRun) {
       if (g.traceur && !self.has('traceur'))
         self.set('traceur', getTranspilerModule(self, 'traceur'));
       if (g.babel && !self.has('babel'))
         self.set('babel', getTranspilerModule(self, 'babel'));
-      firstRun = false;
+      self.transpilerHasRun = true;
     }
     
     return self['import'](self.transpiler).then(function(transpiler) {


### PR DESCRIPTION
This fixes a bug where setting Traceur and/or Babel wasn't happening in
multiple-loader scenarios. Instead of using a closure variable set one
on the loader itself.

Picked a long name to avoid collision. Fixes #347