### PR TITLE
newModule: only use getOwnPropertyNames if obj != null

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1020,7 +1020,7 @@ function logloads(loads) {
       var m = new Module();
 
       var pNames;
-      if (Object.getOwnPropertyNames) {
+      if (Object.getOwnPropertyNames && obj != null) {
         pNames = Object.getOwnPropertyNames(obj);
       }
       else {


### PR DESCRIPTION
If you do:

`System.newModule(null)` this code would have thrown without this fix.