### PR TITLE
Fix console-patching for IE8/9

### DIFF
--- a/src/wrapper-start.js
+++ b/src/wrapper-start.js
@@ -4,9 +4,10 @@
   var isBrowser = typeof window != 'undefined' && typeof document != 'undefined';
   var isWindows = typeof process != 'undefined' && !!process.platform.match(/^win/);
 
-  if (__global.console)
-    console.assert = console.assert || function() {};
-
+  if (!__global.console) {
+      __global.console = { assert: function() {} };
+  }
+  
   // IE8 support
   var indexOf = Array.prototype.indexOf || function(item) {
     for (var i = 0, thisLen = this.length; i < thisLen; i++) {


### PR DESCRIPTION
Hi,

using version 0.16.6. we're getting a 'console undefined' error in IE9.
I've traced it back to this attempt to monkey-patch the console.assert function, which is... well, not working at all ;)

```javascript
if (__global.console)
    console.assert = console.assert || function() {};
```

so I replaced it with this:

```javascript
  if (!__global.console) {
      __global.console = { assert: function() {} };
  }
```

Hope, that's all right.