### PR TITLE
Byte Order Mark included in fulfilled string from SystemLoader.fetch when executed in node

### DIFF
--- a/src/system-fetch.js
+++ b/src/system-fetch.js
@@ -68,8 +68,15 @@
       return fs.readFile(url, function(err, data) {
         if (err)
           return reject(err);
-        else
-          fulfill(data + '');
+        else {
+          // Strip Byte Order Mark out if it's the leading char
+          var dataString = data + '';
+          if (dataString[0] === '\ufeff') {
+            dataString = dataString.length === 1 ? '' : dataString.substr(1);
+          }
+
+          fulfill(dataString);
+        }
       });
     };
   }


### PR DESCRIPTION
Fix for #388