### PR TITLE
Restrict the scopes of __moduleName variables

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -24,7 +24,7 @@ var transpile = (function() {
         transpileFunction = babelTranspile;
 
       // note __moduleName will be part of the transformer meta in future when we have the spec for this
-      return 'var __moduleName = "' + load.name + '";' + transpileFunction.call(self, load, transpiler) + '\n//# sourceURL=' + load.address + '!transpiled';
+      return '(function(){var __moduleName = "' + load.name + '";' + transpileFunction.call(self, load, transpiler) + '})();\n//# sourceURL=' + load.address + '!transpiled';
     });
   };
 


### PR DESCRIPTION
```javascript
// file foo.js
import bar from "bar"
console.log(__moduleName);
```
Without this patch, the code above will output "bar" instead of "foo" if this is the first time "bar" was imported.