### PR TITLE
Restrict scopes of __moduleName

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -24,7 +24,7 @@ var transpile = (function() {
         transpileFunction = babelTranspile;
 
       // note __moduleName will be part of the transformer meta in future when we have the spec for this
-      return 'var __moduleName = "' + load.name + '";' + transpileFunction.call(self, load, transpiler) + '\n//# sourceURL=' + load.address + '!transpiled';
+      return '(function(__moduleName){' + transpileFunction.call(self, load, transpiler) + '\n})("' + load.name + '");\n//# sourceURL=' + load.address + '!transpiled';
     });
   };
 


### PR DESCRIPTION
```javascript
// file foo.js
import bar from "bar"
console.log(__moduleName);
```
Without this patch, the code above will output "bar" instead of "foo" if this is the first time "bar" was imported.