### PR TITLE
Add module/x-module-loader-module as Accept header

### DIFF
--- a/src/system-fetch.js
+++ b/src/system-fetch.js
@@ -47,6 +47,8 @@
       };
       xhr.open("GET", url, true);
 
+      xhr.setRequestHeader('Accept', 'module/x-module-loader-module */*');
+
       if (doTimeout)
         setTimeout(function() {
           xhr.send();


### PR DESCRIPTION
Following up on the discussion here: https://gitter.im/systemjs/systemjs?at=55af92db9402748911923244

Adding an explicit Accept header allows server side middleware to identify requests made specifically to load modules, and thus to hook into the loader chain on the server side.

This is used in https://github.com/Munter/express-systemjs-translate but could potentially open up for a range of other tools to help optimize the development workflow