### PR TITLE
Fix confusing error when XHR statusText is blank

### DIFF
--- a/src/system-fetch.js
+++ b/src/system-fetch.js
@@ -33,7 +33,7 @@
         fulfill(xhr.responseText);
       }
       function error() {
-        reject(new Error(xhr.statusText + ': ' + url || 'XHR error'));
+        reject(new Error('XHR error: status ' + xhr.status + ' "' + xhr.statusText + '": ' + url));
       }
 
       xhr.onreadystatechange = function () {


### PR DESCRIPTION
In the existing `Error(xhr.statusText + ': ' + url || 'XHR error')` implementation, XHR failures with no statusText yield error messages like `: google.com` since the LHS of the `||` is always truthy. This edit changes that to a slightly-less-cryptic `XHR error: status 0 "": http://google.com` (which yields useful results in a web search), or if there is a statusText, `XHR error: status 403 "Forbidden": http://mydomain.com/page`.

(Feel free to just change it directly in the codebase instead of merging if you prefer different formatting, etc.)