### PR TITLE
Allow for loading source maps for files loaded by XHR

### DIFF
--- a/src/system-fetch.js
+++ b/src/system-fetch.js
@@ -23,7 +23,10 @@
         doTimeout = true;
       }
       function load() {
-        fulfill(xhr.responseText);
+        fulfill({
+          source: xhr.responseText,
+          responseHeaders: xhr.getAllResponseHeaders && xhr.getAllResponseHeaders()
+        });
       }
       function error() {
         reject(new Error('XHR error' + (xhr.status ? ' (' + xhr.status + (xhr.statusText ? ' ' + xhr.statusText  : '') + ')' : '') + ' loading ' + url));
@@ -70,7 +73,7 @@
           if (dataString[0] === '\ufeff')
             dataString = dataString.substr(1);
 
-          fulfill(dataString);
+          fulfill({ source: dataString });
         }
       });
     };
@@ -82,5 +85,11 @@
   SystemLoader.prototype.fetch = function(load) {
     return new Promise(function(resolve, reject) {
       fetchTextFromURL(load.address, resolve, reject);
+    }).then(function(result) {
+      if (result.responseHeaders) {
+        load.metadata.responseHeaders = result.responseHeaders;
+      }
+
+      return result.source;
     });
   };


### PR DESCRIPTION
Hi all,

For the application I work on we load source maps via the [SourceMap response header](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#).
This doesn't appear to work currently for files that are loaded via XHR.
From what I can tell XHR loaded source is eval'ed during the instantiation phase but because there is no sourceMappingURL comment in the file the browser doesn't know should be a source map.

I attempted to write a plugin to hook the fetch method:

```javascript
    var system_fetch = System.fetch;
    System.fetch = function(load) {
        var System = this;
        return new Promise(function(resolve, reject) {
            system_fetch.call(System, load).then(function(response) {
                var xhr =
                    ('metadata' in load) &&
                    ('fetch' in load.metadata) &&
                    load.metadata.fetch.xhr;

                if (xhr) {
                    var sm_header = xhr.getResponseHeader('SourceMap');
                    if (sm_header) {
                        response += ';//# sourceMappingURL=' + sm_header;
                    }
                }

                resolve(response);
            }, function(err) {
                reject(err);
            });
        });
    };
```

However, this doesn't work as I do not have access to the XHR object.
This pull request adds the XHR object into the load.metadata so that the above can work
