### PR TITLE
Add if else condition to prevent unspecified error on IE

### DIFF
--- a/src/system-fetch.js
+++ b/src/system-fetch.js
@@ -50,12 +50,13 @@
         }
       }
 
-      if (doTimeout)
+      if (doTimeout) {
         setTimeout(function() {
           xhr.send();
         }, 0);
-
-      xhr.send(null);
+      } else {
+        xhr.send(null);
+      }
     };
   }
   else if (typeof require != 'undefined') {


### PR DESCRIPTION
This change prevents the following error in IE if loading an external resource like jQurey.
Tested on IE8 Win7 + IE9 Win7 and fixes the following problem:
```
SCRIPT16389: Unspecified error.
```