### PR TITLE
new System.noConflict() function to restore state of the global System

### DIFF
--- a/src/wrapper-end.js
+++ b/src/wrapper-end.js
@@ -16,6 +16,11 @@
   if (typeof exports === 'object')
     module.exports = System;
 
+  var oldSystem = __global.System;
+  System.noConflict = function() {
+    __global.System = oldSystem;
+  };
+
   __global.System = System;
 
 })(typeof self != 'undefined' ? self : global);


### PR DESCRIPTION
Hi,

here is a little function you can use to restore the previous state of the global System var if you are using more than one System Instance. 