### PR TITLE
Add support for new async fetch API

### DIFF
--- a/src/system-fetch.js
+++ b/src/system-fetch.js
@@ -59,7 +59,7 @@
       }
     };
   }
-  else if (typeof require != 'undefined') {
+  else if (typeof require != 'undefined' && typeof process != 'undefined') {
     var fs;
     fetchTextFromURL = function(url, authorization, fulfill, reject) {
       if (url.substr(0, 8) != 'file:///')
@@ -83,6 +83,29 @@
         }
       });
     };
+  }
+  else if (typeof self != 'undefined' && typeof self.fetch != 'undefined') {
+    fetchTextFromURL = function(url, authorization, fulfill, reject) {
+      var opts = {
+        headers: {'Accept': 'application/x-es-module, */*'}
+      };
+
+      if (authorization) {
+        if (typeof authorization == 'string')
+          opts.headers['Authorization'] = authorization;
+        opts.credentials = 'include';
+      }
+
+      fetch(url, opts)
+        .then(function (r) {
+          if (r.ok) {
+            return r.text();
+          } else {
+            throw new Error('Fetch error: ' + r.status + ' ' + r.statusText);
+          }
+        })
+        .then(fulfill, reject);
+    }
   }
   else {
     throw new TypeError('No environment fetch API available.');


### PR DESCRIPTION
This commit adds a `fetchTextFromURL` strategy using the new fetch API required for service workers. #374

It can be used in a service worker like this:

```js
importScripts('babel-browser.js')
importScripts('es6-module-loader-dev.js')

self.addEventListener('install', function(event) {
    event.waitUntil(System.import('sw.jsx').then(function(sw) {
        return sw.install(event);
    }));
});

// [..]
```

I did not get a reliable test case working registering and unregistering a service worker due to mismatching URL scopes in test runners.