### PR TITLE
Do not inline source maps for Typescript if compiler option is explicitly set to false

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -70,7 +70,7 @@ var transpile = (function() {
     options.target = options.target || ts.ScriptTarget.ES5;
     if (options.sourceMap === undefined)
       options.sourceMap = true;
-    if (options.sourceMap)
+    if (options.sourceMap && options.inlineSourceMap !== false)
       options.inlineSourceMap = true;
 
     options.module = ts.ModuleKind.System;


### PR DESCRIPTION
This addresses https://github.com/systemjs/builder/issues/177 by allowing users to specify that source-maps should not be inlined--builder does not deal with inline maps properly.