### PR TITLE
Fix for error handling in latest version of traceur

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -47,8 +47,12 @@ var transpile = (function() {
       return compiler.compile(source, filename);
     }
     catch(e) {
-      // traceur throws an error array
-      throw e[0];
+      // on older versions of traceur (<0.9.3), an array of errors is thrown
+      // rather than a single error.
+      if (e.length) {
+        throw e[0];
+      }
+      throw e;
     }
   }
 


### PR DESCRIPTION
Previously, Traceur would return an array of errors when several were detected during compilation. The module loader would just report the first. In 0.9.3 though, Tracuer was [updated to instead](https://github.com/google/traceur-compiler/commit/04a4327f0cf5fa263dc410985dc63c563c030985#diff-654825a71bbcba648d7bf62497eaaec7) throw a single [MultipleErrors](https://github.com/google/traceur-compiler/blob/master/src/util/CollectingErrorReporter.js#L17) type that contains all the errors inside it.

The module loader currently just reports "undefined" as the error, as there is no array with elements, making for a rather opaque error when a compilation error occurs.

This modifies it to still throw the first element when dealing with an array for backwards compatibility, but will otherwise throw the full exception.