### PR TITLE
addToError use original error object

### DIFF
--- a/src/wrapper-start.js
+++ b/src/wrapper-start.js
@@ -34,24 +34,15 @@
   })();
 
   function addToError(err, msg) {
-    var newErr;
+
     if (err instanceof Error) {
-      newErr = new Error(err.message, err.fileName, err.lineNumber);
-      if (isBrowser) {
-        newErr.message = err.message + '\n\t' + msg;
-        newErr.stack = err.stack;
-      }
-      else {
-        // node errors only look correct with the stack modified
-        newErr.message = err.message;
-        newErr.stack = err.stack + '\n\t' + msg;
-      }
+      err.message+= '\n\t' + msg;
     }
     else {
-      newErr = err + '\n\t' + msg;
+      err+= '\n\t' + msg;
     }
-      
-    return newErr;
+
+    return err;
   }
 
   function __eval(source, debugName, context) {


### PR DESCRIPTION
Related to https://github.com/ModuleLoader/es6-module-loader/issues/399 and https://github.com/ModuleLoader/es6-module-loader/pull/404.

From what I understood, `addToError` function (see [wrapper-start.js#L39](https://github.com/ModuleLoader/es6-module-loader/blob/master/src/wrapper-start.js#L39)) is responsible to append a contextual message to give more detail about where an error hapenned.

But I think there is an issue with the current implementation, imagine the following module named `error.js`

```javascript
var typeError = new TypeError('foo is not defined');
throw typeError;
```

And a file importing it

```javascript
System.import('./error.js').catch(function(e){
  console.log(e.name); // e.name is "Error" instead of "TypeError"
});
```
`e.name == 'Error'`because we received error created inside the `addToError` function and not the `typeError` object thrown in `error.js`.
