### PR TITLE
Report errors to console that bubble up during linking

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -473,11 +473,13 @@ function logloads(loads) {
     try {
       link(linkSet, function(load, exc) {
         linkSetFailed(linkSet, load, exc);
+        console.error(exc);
         error = true;
       });
     }
     catch(e) {
       linkSetFailed(linkSet, null, e);
+      console.error(e);
       error = true;
     }
     return error;


### PR DESCRIPTION
This issue was reproduced with SystemJS 0.19.21 which uses es6-module-loader 0.17.10.

I've noticed that some valid errors are currently reported sub-optimally to the console, giving only the "main" message without a full stack, as in:

![truncated-errors](https://cloud.githubusercontent.com/assets/279572/13386033/7a510b1e-de6d-11e5-9d25-194715a14c7c.png)

If we instead use `console.error` to report these, you get a full stack trace and much more useful information:

![full-stack](https://cloud.githubusercontent.com/assets/279572/13386080/fc0699bc-de6d-11e5-99e4-e27ad63e3a8a.png)

I am not sure if this is the right place to add such logging, so there may easily be a better way to add this kind of logging. In any case, this has helped me a lot when debugging errors.