### PR TITLE
remove options.modules in babelTranspile

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -58,7 +58,6 @@ var transpile = (function() {
 
   function babelTranspile(load, babel) {
     var options = this.babelOptions || {};
-    options.modules = 'system';
     if (options.sourceMap === undefined)
       options.sourceMap = 'inline';
     options.inputSourceMap = load.metadata.sourceMap;


### PR DESCRIPTION
options.modules = 'system' is deprecated in Babel 6

And this will lead to error 

> Using removed Babel 5 option: base.modules - Use the corresponding module transform plugin in the plugins option. Check out http://babeljs.io/docs/plugins/#modules(…)