### PR TITLE
Ensuring that es6 modules are interpreted as es6 modules by today's bundlers/loaders

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function(config) {
 
   var files = [
     'test/_helper.js',
-    [options['babel'] ? 'node_modules/regenerator/runtime.js' : ''],
+    [options['babel'] ? 'node_modules/regenerator-runtime/runtime.js' : ''],
 
     [!options.ie8 
         ? (options['babel'] 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "karma-sauce-launcher": "^0.2.10",
     "minimist": "^1.1.0",
     "mocha": "^2.0.1",
-    "regenerator": "^0.8.9",
+    "regenerator-runtime": "^0.9.5",
     "traceur": "0.0.93",
     "typescript": "^1.6.2"
   },

--- a/src/loader.js
+++ b/src/loader.js
@@ -18,7 +18,11 @@
 *********************************************************************************************
 */
 
-function Module() {}
+function Module() {
+	if (this) {
+		this.__esModule = true;
+	}
+}
 // http://www.ecma-international.org/ecma-262/6.0/#sec-@@tostringtag
 defineProperty(Module.prototype, 'toString', {
   value: function() {

--- a/src/loader.js
+++ b/src/loader.js
@@ -19,7 +19,7 @@
 */
 
 function Module() {
-	if (this) {
+	if (typeof this === 'object') {
 		this.__esModule = true;
 	}
 }

--- a/test/_node-babel.js
+++ b/test/_node-babel.js
@@ -4,7 +4,7 @@ global.expect = require('expect.js');
 
 require('./_helper');
 
-require('regenerator/runtime');
+require('regenerator-runtime/runtime');
 
 global.System = require('../index').System;
 global.System.transpiler = 'babel';


### PR DESCRIPTION
See jspm/jspm-cli#1793 for the problem that this fixes. Basically, `Module` objects are not being interpreted as es6 modules by systemjs/builder because they do not define the _esModule property to be true. See [code in the builder](https://github.com/systemjs/builder/blob/master/templates/sfx-core-register.js#L257-L260) for why this is the case.

Interested to know of any problems/concerns anyone has with doing this, but I believe that this is a backwards compatible change unless people are depending on `Module`s *not* being interpreted as es modules.