### PR TITLE
Limit Travis to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
   - "[ $SAUCE_LABS == false ] || npm run test:browser-$PARSER -- --saucelabs $OPTIONS"
 
 branches:
-  except:
-    - 0.50
+  only:
+    - master


### PR DESCRIPTION
I think I may be misunderstanding https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches - depends on whether the branch to ignore is the branch being merged or the branch into which the new branch is being merged. Either way, if we change it to master only, then it should not build any others. As and when we need Travis to run on another branch, we can add it to this whitelist.